### PR TITLE
🐛 fixed CI/CD pipeline for API fails

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -7,7 +7,7 @@
 # frontend can be found at vsnthdev/alpa-app.
 
 # small & updated base image
-FROM node:17-alpine3.13
+FROM node:17.8.0-alpine3.15
 
 # run Node.js in production so the API
 # can take the necessary security measures

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -7,7 +7,7 @@
 # API can be found at vsnthdev/alpa-api.
 
 # small & updated base image
-FROM node:17-alpine3.13
+FROM node:17.8.0-alpine3.15
 
 # run Node.js in production
 ENV NODE_ENV=production

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "chalk": "^5.0.0",
                 "es-dirname": "^0.1.0",
                 "glob": "^7.2.0",
+                "husky": "^7.0.4",
                 "itivrutaha": "^2.0.13",
                 "js-yaml": "^4.1.0",
                 "lerna": "^4.0.0"
@@ -22,7 +23,6 @@
                 "@types/js-yaml": "^4.0.5",
                 "@types/node": "^17.0.13",
                 "concurrently": "^7.0.0",
-                "husky": "^7.0.4",
                 "rimraf": "^3.0.2",
                 "typescript": "^4.5.5"
             },
@@ -3353,7 +3353,6 @@
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
             "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
-            "dev": true,
             "bin": {
                 "husky": "lib/bin.js"
             },
@@ -9828,8 +9827,7 @@
         "husky": {
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-            "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
-            "dev": true
+            "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ=="
         },
         "iconv-lite": {
             "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "chalk": "^5.0.0",
         "es-dirname": "^0.1.0",
         "glob": "^7.2.0",
+        "husky": "^7.0.4",
         "itivrutaha": "^2.0.13",
         "js-yaml": "^4.1.0",
         "lerna": "^4.0.0"
@@ -39,7 +40,6 @@
         "@types/js-yaml": "^4.0.5",
         "@types/node": "^17.0.13",
         "concurrently": "^7.0.0",
-        "husky": "^7.0.4",
         "rimraf": "^3.0.2",
         "typescript": "^4.5.5"
     }


### PR DESCRIPTION
Seems like GitHub caches Docker images for Node.js 🤷‍♂️

Previously I was only specific about the major version of Docker base image for both `@alpa/api` and `@alpa/app`. It is causing GitHub Actions to use an unsupported Node.js version which results in building of the projects.

This small fix will fix Node.js version to 17.8.0 (latest at the time) which should be support to fix the CI/CD pipeline build failure.